### PR TITLE
One editable parameter file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The record player uses Radio-frequency identification (RFID), the same technolog
 In this project, the RFID scanner module is mounted inside the wooden box, and the vinyls all have an RFID sticker that can be tapped on the box to switch the album. Inside the box, the RFID scanner is wired to a Raspberry Pi, which is running a python program that switches the song based on the value it reads from the RFID scanner. Depending on the RFID sticker value, the corresponding album is played through the Spotify API.  
 
 I wrote a very detailed blog post with all the steps you need here:
+NOTE: Instructions have been changed. Copy file `musicAndParameters.py` onto your RasPy first and only edit this file.
 https://talaexe.com/moderndayrecordplayer
 
 You can also watch the YouTube video here if you prefer.

--- a/musicAndParameters.py
+++ b/musicAndParameters.py
@@ -1,0 +1,32 @@
+'''
+This is the only file you need to edit. 
+1. Edit lines 13-16 with your Spotify details
+2. Run spotifyTest.py
+3. Run player.py or add song/albums on lines 23 and 31
+    (make sure to follow the correct formats)
+'''
+
+def init():
+    global DEVICE_ID, CLIENT_ID, CLIENT_SECRET
+    global SONGS, ALBUMS
+
+    # Edit the Spotify IDs and CLIENT_Secret below
+    DEVICE_ID="YOUR_DEVICE_ID"
+    CLIENT_ID="YOUR_CLIENT_ID"
+    CLIENT_SECRET="YOUR_CLIENT_SECRET"
+
+    # Add songs below if you want one RFID to play one song
+    SONGS = {
+        # Format:
+        #   RFID-CARDVALUE: 'uris_Value'
+        865269176938: 'spotify:track:2vSLxBSZoK0eha4AuhZlXV',
+        246835529022: 'spotify:track:4PTG3Z6ehGkBFwjybzWkR8',
+    }
+
+    # Add albums below if you want one RFID to play an album
+    ALBUMS = {
+        # Format:
+        #   RFID-CARDVALUE: 'context_uri_value',
+        865202068078: 'spotify:album:0JGOiO34nwfUdDrD612dOp',
+        246777109145: 'spotify:album:6eUW0wxWtzkFdaEFsTJto6',
+    }

--- a/player.py
+++ b/player.py
@@ -4,24 +4,7 @@ import RPi.GPIO as GPIO
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 from time import sleep
-
-DEVICE_ID="YOUR_DEVICE_ID"
-CLIENT_ID="YOUR_CLIENT_ID"
-CLIENT_SECRET="YOUR_CLIENT_SECRET"
-
-# Edit here to add one song per RFID tag
-SONGS = {
-    # Format:
-    #   RFID-CARDVALUE: 'uris_Value'
-    865269176938: 'spotify:track:2vSLxBSZoK0eha4AuhZlXV',
-}
-
-# Edit here to add an album per RFID tag
-ALBUMS = {
-    # Format:
-    #   RFID-CARDVALUE: 'context_uri_value',
-    865202068078: 'spotify:album:0JGOiO34nwfUdDrD612dOp',
-}
+from musicAndParameters import *
 
 while True:
     try:
@@ -38,7 +21,7 @@ while True:
             print("Card Value is:",id)
             sp.transfer_playback(device_id=DEVICE_ID, force_play=False)
             
-            # DONT edit here
+            # DONT edit here. Only edit the musicAndParameters.py file
             if id in SONGS.keys():
 
                 # playing a song

--- a/player.py
+++ b/player.py
@@ -9,6 +9,20 @@ DEVICE_ID="YOUR_DEVICE_ID"
 CLIENT_ID="YOUR_CLIENT_ID"
 CLIENT_SECRET="YOUR_CLIENT_SECRET"
 
+# Edit here to add one song per RFID tag
+SONGS = {
+    # Format:
+    #   RFID-CARDVALUE: 'uris_Value'
+    865269176938: 'spotify:track:2vSLxBSZoK0eha4AuhZlXV',
+}
+
+# Edit here to add an album per RFID tag
+ALBUMS = {
+    # Format:
+    #   RFID-CARDVALUE: 'context_uri_value',
+    865202068078: 'spotify:album:0JGOiO34nwfUdDrD612dOp',
+}
+
 while True:
     try:
         reader=SimpleMFRC522()
@@ -24,20 +38,18 @@ while True:
             print("Card Value is:",id)
             sp.transfer_playback(device_id=DEVICE_ID, force_play=False)
             
-            # DONT include the quotation marks around the card's ID value, just paste the number
-            if (id=='RFID-CARDVALUE-1'):
-                
+            # DONT edit here
+            if id in SONGS.keys():
+
                 # playing a song
-                sp.start_playback(device_id=DEVICE_ID, uris=['spotify:track:2vSLxBSZoK0eha4AuhZlXV'])
+                sp.start_playback(device_id=DEVICE_ID, uris=[ SONGS[id] ])
                 sleep(2)
                 
-            elif (id=='RFID-CARDVALUE-2'):
+            elif id in ALBUMS.keys():
                 
                 # playing an album
-                sp.start_playback(device_id=DEVICE_ID, context_uri='spotify:album:0JGOiO34nwfUdDrD612dOp')
+                sp.start_playback(device_id=DEVICE_ID, context_uri= ALBUMS[id])
                 sleep(2)
-                
-            # continue adding as many "elifs" for songs/albums that you want to play
 
     # if there is an error, skip it and try the code again (i.e. timeout issues, no active device error, etc)
     except Exception as e:

--- a/spotifyTest.py
+++ b/spotifyTest.py
@@ -2,10 +2,7 @@
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 from time import sleep
-
-DEVICE_ID="YOUR_DEVICE_ID"
-CLIENT_ID="YOUR_CLIENT_ID"
-CLIENT_SECRET="YOUR_CLIENT_SECRET"
+from musicAndParameters import *
 
 # Spotify Authentication
 sp = spotipy.Spotify(auth_manager=SpotifyOAuth(client_id=CLIENT_ID,


### PR DESCRIPTION
1. Previously, the user had to copy and paste an elif for each song/album they wanted to add.
All the `elif`s have been modified so the user only needs to add to a dictionary to add add a song instead of copying and pasting.
The dictionary is located in the `musicAndParameters.py` file.
2. The current user method includes editing two files with the same Spotify IDs.
This takes all the editing and puts it into one parameter file `musicAndParameters.py`

The goal of these changes is hopefully its easier for people with little programming experience. Less things to change and less things to mess up. 